### PR TITLE
Use solver to validate depends stanza

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
  (public_name opam-publish)
  (package opam-publish)
  (name publishMain)
- (libraries lwt opam-core opam-format opam-state cohttp github.unix cmdliner))
+ (libraries lwt opam-core opam-format opam-solver opam-state cohttp github.unix cmdliner))
 
 (rule
   (targets version.ml)


### PR DESCRIPTION
Humbly submitted as a solution for https://github.com/ocaml/opam-publish/issues/94

It basically works for a few repos that I've spot-tested, but it bombs out if "build" is listed in the depends stanza.

I've less time to dig into this than when I started, and this was just languishing on my box, so I thought it'd be better to expose it to light now in case it's an obvious fix to people with more knowledge of opam.
