### PR TITLE
Add --no-browser flag

### DIFF
--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -434,6 +434,11 @@ module Args = struct
     info ["n";"dry-run"] ~docs ~doc:
       "Show what would be submitted, but don't file a pull-request"
 
+  let open_browser =
+    value & opt bool true &
+    info ["open-browser"] ~docs ~docv:"BOOL" ~doc:
+      "Open the browser after submitting a pull-request, set to false to disable"
+
   let repo =
     value & opt repo_conv ("ocaml", "opam-repository") &
     info ["repo"] ~docs ~docv:"REPO" ~doc:
@@ -603,7 +608,7 @@ let to_files ?(split=false) ~packages_dir meta_opams =
   |> List.rev
 
 let main_term root =
-  let run args force tag version dry_run repo target_branch packages_dir title msg split =
+  let run args force tag version dry_run open_browser repo target_branch packages_dir title msg split =
     let dirs, opams, urls, projects, names =
       List.fold_left (fun (dirs, opams, urls, projects, names) -> function
           | `Dir d -> (dirs @ [d], opams, urls, projects, names)
@@ -626,13 +631,14 @@ let main_term root =
     PublishSubmit.submit
       root
       ~dry_run
+      ~open_browser
       repo target_branch pr_title pr_body
       (OpamPackage.Map.keys meta_opams)
       files
   in
   let open Args in
   Term.(pure run
-        $ src_args $ force $ tag $ version $ dry_run
+        $ src_args $ force $ tag $ version $ dry_run $ open_browser
         $ repo $ target_branch $ packages_dir $ title $ msg_file $ split)
 
 

--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -434,10 +434,10 @@ module Args = struct
     info ["n";"dry-run"] ~docs ~doc:
       "Show what would be submitted, but don't file a pull-request"
 
-  let open_browser =
-    value & opt bool true &
-    info ["open-browser"] ~docs ~docv:"BOOL" ~doc:
-      "Open the browser after submitting a pull-request, set to false to disable"
+  let no_browser =
+    value & flag &
+    info ["no-browser"] ~docs ~doc:
+      "Disables opening the browser after submitting a pull-request"
 
   let repo =
     value & opt repo_conv ("ocaml", "opam-repository") &
@@ -608,7 +608,7 @@ let to_files ?(split=false) ~packages_dir meta_opams =
   |> List.rev
 
 let main_term root =
-  let run args force tag version dry_run open_browser repo target_branch packages_dir title msg split =
+  let run args force tag version dry_run no_browser repo target_branch packages_dir title msg split =
     let dirs, opams, urls, projects, names =
       List.fold_left (fun (dirs, opams, urls, projects, names) -> function
           | `Dir d -> (dirs @ [d], opams, urls, projects, names)
@@ -631,14 +631,14 @@ let main_term root =
     PublishSubmit.submit
       root
       ~dry_run
-      ~open_browser
+      ~no_browser
       repo target_branch pr_title pr_body
       (OpamPackage.Map.keys meta_opams)
       files
   in
   let open Args in
   Term.(pure run
-        $ src_args $ force $ tag $ version $ dry_run $ open_browser
+        $ src_args $ force $ tag $ version $ dry_run $ no_browser
         $ repo $ target_branch $ packages_dir $ title $ msg_file $ split)
 
 

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -294,7 +294,7 @@ let update_mirror root repo branch =
   git_command ~dir ["reset"; "origin"/branch; "--hard"]
 
 let add_files_and_pr
-    root ?(dry_run=false) repo user token title message
+    root ?(dry_run=false) ?(open_browser=true) repo user token title message
     branch target_branch files =
   let mirror = repo_dir root repo in
   let () =
@@ -324,6 +324,7 @@ let add_files_and_pr
     GH.pull_request title user token repo ~text:message branch target_branch
   in
   OpamConsole.msg "Pull-requested: %s\n" url;
+  if not open_browser then () else
   try
     let auto_open =
       if OpamStd.Sys.(os () = Darwin) then "open" else "xdg-open"
@@ -331,7 +332,7 @@ let add_files_and_pr
     OpamSystem.command [auto_open; url]
   with OpamSystem.Command_not_found _ -> ()
 
-let submit root ?dry_run repo target_branch title msg packages files =
+let submit root ?dry_run ?open_browser repo target_branch title msg packages files =
   (* Prepare the repo *)
   let mirror_dir = repo_dir root repo in
   let user, token =
@@ -346,4 +347,4 @@ let submit root ?dry_run repo target_branch title msg packages files =
   (* pull-request processing *)
   update_mirror root repo target_branch;
   let branch = user_branch packages in
-  add_files_and_pr root ?dry_run repo user token title msg branch target_branch files
+  add_files_and_pr root ?dry_run ?open_browser repo user token title msg branch target_branch files

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -294,7 +294,7 @@ let update_mirror root repo branch =
   git_command ~dir ["reset"; "origin"/branch; "--hard"]
 
 let add_files_and_pr
-    root ?(dry_run=false) ?(open_browser=true) repo user token title message
+    root ?(dry_run=false) ?(no_browser=false) repo user token title message
     branch target_branch files =
   let mirror = repo_dir root repo in
   let () =
@@ -324,7 +324,7 @@ let add_files_and_pr
     GH.pull_request title user token repo ~text:message branch target_branch
   in
   OpamConsole.msg "Pull-requested: %s\n" url;
-  if not open_browser then () else
+  if no_browser then () else
   try
     let auto_open =
       if OpamStd.Sys.(os () = Darwin) then "open" else "xdg-open"
@@ -332,7 +332,7 @@ let add_files_and_pr
     OpamSystem.command [auto_open; url]
   with OpamSystem.Command_not_found _ -> ()
 
-let submit root ?dry_run ?open_browser repo target_branch title msg packages files =
+let submit root ?dry_run ?no_browser repo target_branch title msg packages files =
   (* Prepare the repo *)
   let mirror_dir = repo_dir root repo in
   let user, token =
@@ -347,4 +347,4 @@ let submit root ?dry_run ?open_browser repo target_branch title msg packages fil
   (* pull-request processing *)
   update_mirror root repo target_branch;
   let branch = user_branch packages in
-  add_files_and_pr root ?dry_run ?open_browser repo user token title msg branch target_branch files
+  add_files_and_pr root ?dry_run ?no_browser repo user token title msg branch target_branch files

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -324,13 +324,14 @@ let add_files_and_pr
     GH.pull_request title user token repo ~text:message branch target_branch
   in
   OpamConsole.msg "Pull-requested: %s\n" url;
-  if no_browser then () else
-  try
-    let auto_open =
-      if OpamStd.Sys.(os () = Darwin) then "open" else "xdg-open"
-    in
-    OpamSystem.command [auto_open; url]
-  with OpamSystem.Command_not_found _ -> ()
+  if not no_browser then begin
+    try
+      let auto_open =
+        if OpamStd.Sys.(os () = Darwin) then "open" else "xdg-open"
+      in
+      OpamSystem.command [auto_open; url]
+    with OpamSystem.Command_not_found _ -> ()
+  end
 
 let submit root ?dry_run ?no_browser repo target_branch title msg packages files =
   (* Prepare the repo *)


### PR DESCRIPTION
Ref #109 

This adds an option called `--open-browser` that a user can set to false to disable the open browser logic in a headless environment.