### PR TITLE
Remove the personal access token creation (API deleted by GitHub).

### DIFF
--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -105,14 +105,10 @@ module GH = struct
     else
     let token =
       OpamConsole.msg
-        "In order to continue, you will be required to provide your GitHub \
-         personal access token. This personal acces token requires the \
-         \"public_repo\" scope (or \"repo\" if you submit to a private \
-         repository).\n\
-         You can manage your personal access token at \
-         https://github.com/settings/tokens\n\
-         Note: your GitHub password will not work, only a personal access token \
-         can authenticates you.\n\n";
+        "Please generate a Github token at \
+         https://github.com/settings/tokens/new to allow access.\n\
+         The \"public_repo\" scope is required (\"repo\" if submitting to a \
+         private opam repository).\n\n";
       let token =
         let rec get_pass () =
           match


### PR DESCRIPTION
Since last November, GitHub have [deleted its Authorizations API ](https://github.blog/changelog/2020-11-13-token-authentication-required-for-api-operations/) which was used here to create/delete personal access token. This API being unavailable, this PR removes all references to token creation/deletion, and asks the users to provide directly a personal access token instead of his password.

This pull-request removes the 2FA authentication, because it becomes useless with personal access token (according to the documentation).

Related issues:
- #104 (latests messages)
- #115 
- #116 (may partially solves this issue ?)
- #119