### PR TITLE
main: Make the code compile

### DIFF
--- a/opam-publish.opam
+++ b/opam-publish.opam
@@ -12,7 +12,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.1.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -674,13 +674,13 @@ let main_term root =
       files
   in
   let open Args in
-  Term.(pure run
+  Term.(const run
         $ src_args $ force $ tag $ version $ dry_run $ output_patch $ no_browser
         $ repo $ target_branch $ packages_dir $ title $ msg_file $ split)
 
 
 let main_info =
-  Term.info "opam-publish"
+  Cmd.info "opam-publish"
     ~version:Version.version
     ~doc:"Helper for package publications on opam repositories"
     ~man:[
@@ -737,11 +737,11 @@ let () =
   OpamCoreConfig.init ();
   OpamStateConfig.init ~root_dir:opam_root ();
   let publish_root = OpamFilename.Op.(opam_root / "plugins" / "opam-publish") in
-  let main_command = (main_term publish_root, main_info) in
+  let main_command = Cmd.v main_info (main_term publish_root) in
   try
-    match Term.eval ~catch:false main_command with
-    | `Ok () | `Version | `Help -> OpamStd.Sys.exit_because `Success
-    | `Error _ -> OpamStd.Sys.exit_because `Bad_arguments
+    match Cmd.eval_value ~catch:false main_command with
+    | Ok (`Ok () | `Version | `Help) -> OpamStd.Sys.exit_because `Success
+    | Error _ -> OpamStd.Sys.exit_because `Bad_arguments
   with
   | OpamStd.Sys.Exit i -> exit i
   | Failure e ->

--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -737,8 +737,9 @@ let () =
   OpamCoreConfig.init ();
   OpamStateConfig.init ~root_dir:opam_root ();
   let publish_root = OpamFilename.Op.(opam_root / "plugins" / "opam-publish") in
+  let main_command = (main_term publish_root, main_info) in
   try
-    match Term.eval ~catch:false (main_term publish_root, main_info) with
+    match Term.eval ~catch:false main_command with
     | `Ok () | `Version | `Help -> OpamStd.Sys.exit_because `Success
     | `Error _ -> OpamStd.Sys.exit_because `Bad_arguments
   with


### PR DESCRIPTION
To do so, we need to switch to Cmdliner 1.1.

See
https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md#new-cmd-module-and-deprecation-of-the-term-evaluation-interface
for migration guide.
