### PR TITLE
Remove the need for valid SSH keys linked to your github when using opam-publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,11 @@
-all: opam-publish
+all: build
 
 ALWAYS:
 	@
 
-opam-publish: ALWAYS
-	dune build _build/default/src/publishMain.exe
-	@cp _build/default/src/publishMain.exe $@
-
 build: ALWAYS
-	dune build @install --dev
+	dune build @install
+	cp _build/default/src/publishMain.exe ./opam-publish
 
 install: ALWAYS
 	dune install

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -20,7 +20,7 @@ let () =
 
 let (/) a b = String.concat "/" [a;b]
 
-let github_root = "git@github.com:"
+let github_root ~token = Github.Token.to_string token^"@github.com:"
 
 type github_repo = string * string (* owner, name *)
 
@@ -227,10 +227,10 @@ let init_mirror root repo user token =
     "Cloning the package repository, this may take a while...\n";
   git_command ~verbose:true
     ["clone";
-     github_root^(fst repo)/(snd repo)^".git";
+     github_root ~token^(fst repo)/(snd repo)^".git";
      OpamFilename.Dir.to_string dir];
   GH.fork token repo;
-  git_command ~dir ["remote"; "add"; "user"; github_root^user/(snd repo)]
+  git_command ~dir ["remote"; "add"; "user"; github_root ~token^user/(snd repo)]
 
 let update_mirror root repo ~user ~token branch =
   let dir = repo_dir root repo in


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam/issues/5620

cc @johnwhitington if you haven't added SSH keys to your profile yet, could you try if this fixes your issue?