### PR TITLE
Add a --no-confirmation option

### DIFF
--- a/src/publishMain.ml
+++ b/src/publishMain.ml
@@ -665,13 +665,14 @@ let main_term root =
         ([], [], [], [], [])
         args
     in
-    if no_confirmation then
+    if no_confirmation then begin
       if OpamStd.Sys.tty_in then
         OpamConsole.error_and_exit `Bad_arguments
           "'--no-confirmation' is not allowed in interactive mode. Please \
            review before submitting"
       else
-        OpamCoreConfig.update ~confirm_level:`unsafe_yes ();
+        OpamCoreConfig.update ~confirm_level:`unsafe_yes ()
+    end;
     let meta_opams =
       get_opams force dirs opams urls projects tag names version
     in

--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -285,7 +285,8 @@ let add_files_and_pr
         (fst repo) (snd repo) (OpamFilename.to_string out)
   end;
   if output_patch <> None || dry_run then OpamStd.Sys.exit_because `Success;
-  if not (OpamConsole.confirm "\nFile a pull-request for this patch ?") then
+  if not (OpamConsole.confirm ~require_unsafe_yes:true
+            "\nFile a pull-request for this patch ?") then
     OpamStd.Sys.exit_because `Aborted;
   let url =
     GH.pull_request title user token repo ~text:message branch target_branch


### PR DESCRIPTION
This might be required for some complex release pipelines where the package is already guaranteed to be well reviewed and checked before `opam-publish` is called.

I took care to add some safeguards to avoid copy-paste of ill-advised one-liners that would result in people submitting unreviewed releases and increasing the strain on the repository maintainers.