### PR TITLE
Add message about re-running to update PRs

### DIFF
--- a/src/publishSubmit.ml
+++ b/src/publishSubmit.ml
@@ -293,6 +293,7 @@ let add_files_and_pr
     GH.pull_request title user token repo ~text:message branch target_branch
   in
   OpamConsole.msg "Pull-requested: %s\n" url;
+  OpamConsole.msg "You can re-run this command to update the pull-request.\n";
   if not no_browser then begin
     try
       let auto_open =


### PR DESCRIPTION
Package authors often close PRs and open new ones (on the
ocaml/opam-repository), possibly because of lack of awareness that
opam-publish can update open PRs. This PR adds a message to inform users
about re-running the command to update PRs after creating a new PR.
