### PR TITLE
Switch from lwt_ssl to tls-lwt

### DIFF
--- a/opam-publish.opam
+++ b/opam-publish.opam
@@ -14,16 +14,13 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "1.0"}
-  "lwt_ssl"
+  "tls-lwt" {>= "0.16.0"}
   "ocaml" {>= "4.08.0"}
   "opam-core" {>= "2.2.0"}
   "opam-format" {>= "2.2.0"}
   "opam-state" {>= "2.2.0"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
-]
-conflicts: [
-  "ssl" {= "0.5.6"}
 ]
 flags: plugin
 synopsis: "A tool to ease contributions to opam repositories"


### PR DESCRIPTION
This switches from a C binding to libssl to an OCaml implementation of TLS. Doing so avoids one extra opam dependency (conf-libssl) and its associated depext which can sometimes be problematic on some platforms.

In a sense this inverts a change made in https://github.com/ocaml-opam/opam-publish/pull/71 which chose `ssl` over `tls`. The reason, while not explicitly stated, i believe was something like "`tls` has way much dependencies than `ssl`", however `tls` has come a long way since, and it now has less dependencies than `ssl` for us (since other dependencies such as `x509` and `ca-certs` are already dependencies of `conduit-lwt-unix` that we depend through `github-unix`)